### PR TITLE
Few math function tweaks and Wsign-conversion warning fix

### DIFF
--- a/AGA8CODE/C/Detail.cpp
+++ b/AGA8CODE/C/Detail.cpp
@@ -92,10 +92,6 @@ static double n0i[MaxFlds+1][7+1], th0i[MaxFlds+1][7+1];
 static double MMiDetail[MaxFlds+1], K3, xold[MaxFlds+1];
 static double dPdDsave; //Calculated in the Pressure subroutine, but not included as an argument since it is only used internally in the density algorithm.
 
-inline double Tanh(double xx){ return (exp(xx) - exp(-xx)) / (exp(xx) + exp(-xx)); }
-inline double Sinh(double xx){ return (exp(xx) - exp(-xx)) / 2; }
-inline double Cosh(double xx){ return (exp(xx) + exp(-xx)) / 2; }
-
 void MolarMassDetail(const std::vector<double> &x, double &Mm)
 {
     // Calculate molar mass of the mixture with the compositions contained in the x() input array
@@ -963,10 +959,10 @@ void SetupDetail()
     // d0 = 101.325 / RDetail / T0;
     // for (int i=1; i <= MaxFlds; ++i){
     //   n1 = 0; n2 = 0;
-    //   if (th0i[i][4] > 0) {n2 = n2 - n0i[i][4] * th0i[i][4] / Tanh(th0i[i][4] / T0); n1 = n1 - n0i[i][4] * log(Sinh(th0i[i][4] / T0));}
-    //   if (th0i[i][5] > 0) {n2 = n2 + n0i[i][5] * th0i[i][5] * Tanh(th0i[i][5] / T0); n1 = n1 + n0i[i][5] * log(Cosh(th0i[i][5] / T0));}
-    //   if (th0i[i][6] > 0) {n2 = n2 - n0i[i][6] * th0i[i][6] / Tanh(th0i[i][6] / T0); n1 = n1 - n0i[i][6] * log(Sinh(th0i[i][6] / T0));}
-    //   if (th0i[i][7] > 0) {n2 = n2 + n0i[i][7] * th0i[i][7] * Tanh(th0i[i][7] / T0); n1 = n1 + n0i[i][7] * log(Cosh(th0i[i][7] / T0));}
+    //   if (th0i[i][4] > 0) {n2 = n2 - n0i[i][4] * th0i[i][4] / tanh(th0i[i][4] / T0); n1 = n1 - n0i[i][4] * log(sinh(th0i[i][4] / T0));}
+    //   if (th0i[i][5] > 0) {n2 = n2 + n0i[i][5] * th0i[i][5] * tanh(th0i[i][5] / T0); n1 = n1 + n0i[i][5] * log(cosh(th0i[i][5] / T0));}
+    //   if (th0i[i][6] > 0) {n2 = n2 - n0i[i][6] * th0i[i][6] / tanh(th0i[i][6] / T0); n1 = n1 - n0i[i][6] * log(sinh(th0i[i][6] / T0));}
+    //   if (th0i[i][7] > 0) {n2 = n2 + n0i[i][7] * th0i[i][7] * tanh(th0i[i][7] / T0); n1 = n1 + n0i[i][7] * log(cosh(th0i[i][7] / T0));}
     //   n0i[i][2] = n2 - n0i[i][3] * T0;
     //   n0i[i][3] = n0i[i][3] - 1;
     //   n0i[i][1] = n1 - n2 / T0 + n0i[i][3] * (1 + log(T0)) - log(d0);

--- a/AGA8CODE/C/Detail.cpp
+++ b/AGA8CODE/C/Detail.cpp
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <cmath>
 #include <iostream>
+#include <cstdint>
 
 //  **********  This code is preliminary, and will be updated.  **********
 //  **********  Use only for beta testing.  **********
@@ -106,7 +107,7 @@ void MolarMassDetail(const std::vector<double> &x, double &Mm)
     //     Mm - Molar mass (g/mol)
 
     Mm = 0;
-    for(int i = 1; i <= NcDetail; ++i){
+    for(std::size_t i = 1; i <= NcDetail; ++i){
         Mm += x[i]*MMiDetail[i];
     }
 }
@@ -289,7 +290,7 @@ static void xTermsDetail(const std::vector<double> &x)
 
     // Check to see if a component fraction has changed.  If x is the same as the previous call, then exit.
     icheck = 0;
-    for (int i = 1; i <= NcDetail; ++i){
+    for (std::size_t i = 1; i <= NcDetail; ++i){
         if (std::abs(x[i] - xold[i]) > 0.0000001) { icheck = 1; }
         xold[i] = x[i];
     }
@@ -299,7 +300,7 @@ static void xTermsDetail(const std::vector<double> &x)
     for (int n = 1; n <= 18; ++n) {Bs[n] = 0; }
 
     // Calculate pure fluid contributions
-    for (int i = 1; i <= NcDetail; ++i){
+    for (std::size_t i = 1; i <= NcDetail; ++i){
         if (x[i] > 0 ) {
             xi2 = pow(x[i], 2);
             K3 += x[i] * Ki25[i];   // K, U, and G are the sums of a pure fluid contribution and a
@@ -316,9 +317,9 @@ static void xTermsDetail(const std::vector<double> &x)
     U = pow(U, 2);
 
     // Binary pair contributions
-    for (int i = 1; i <= NcDetail - 1; ++i){
+    for (std::size_t i = 1; i <= NcDetail - 1; ++i){
         if (x[i] > 0) {
-            for (int j = i + 1; j <= NcDetail; ++j){
+            for (std::size_t j = i + 1; j <= NcDetail; ++j){
                 if (x[j] > 0) {
                     xij = 2 * x[i] * x[j];
                     K3 = K3 + xij * Kij5[i][j];
@@ -367,7 +368,7 @@ static void Alpha0Detail(const double T, const double D, const std::vector<doubl
     a0[0] = 0; a0[1] = 0; a0[2] = 0;
     if (D > epsilon) { LogD = log(D); } else {LogD = log(epsilon);}
     LogT = log(T);
-    for (int i = 1; i <= NcDetail; ++i) {
+    for (std::size_t i = 1; i <= NcDetail; ++i) {
         if (x[i] > 0) {
             LogxD = LogD + log(x[i]);
             SumHyp0 = 0;

--- a/AGA8CODE/C/Detail.cpp
+++ b/AGA8CODE/C/Detail.cpp
@@ -5,7 +5,7 @@
 #include <math.h>
 #include <cmath>
 #include <iostream>
-#include <cstdint>
+#include <cstdlib>
 
 //  **********  This code is preliminary, and will be updated.  **********
 //  **********  Use only for beta testing.  **********

--- a/AGA8CODE/C/Detail.cpp
+++ b/AGA8CODE/C/Detail.cpp
@@ -93,6 +93,8 @@ static double n0i[MaxFlds+1][7+1], th0i[MaxFlds+1][7+1];
 static double MMiDetail[MaxFlds+1], K3, xold[MaxFlds+1];
 static double dPdDsave; //Calculated in the Pressure subroutine, but not included as an argument since it is only used internally in the density algorithm.
 
+inline double sq(double x) { return x*x; }
+
 void MolarMassDetail(const std::vector<double> &x, double &Mm)
 {
     // Calculate molar mass of the mixture with the compositions contained in the x() input array
@@ -258,7 +260,7 @@ void PropertiesDetail(const double T, const double D, const std::vector<double> 
     if (D > epsilon) {
         H = U + P / D;
         G = A + P / D;
-        Cp = Cv + T * pow(dPdT / D, 2) / dPdD;
+        Cp = Cv + T * sq(dPdT / D) / dPdD;
         d2PdD2 = (2 * ar[0][1] + 4 * ar[0][2] + ar[0][3]) / D;
         JT = (T / D * dPdT / dPdD - 1) / Cp / D;
     }
@@ -302,7 +304,7 @@ static void xTermsDetail(const std::vector<double> &x)
     // Calculate pure fluid contributions
     for (std::size_t i = 1; i <= NcDetail; ++i){
         if (x[i] > 0 ) {
-            xi2 = pow(x[i], 2);
+            xi2 = sq(x[i]);
             K3 += x[i] * Ki25[i];   // K, U, and G are the sums of a pure fluid contribution and a
             U += x[i] * Ei25[i];    // binary pair contribution
             G += x[i] * Gi[i];
@@ -313,8 +315,8 @@ static void xTermsDetail(const std::vector<double> &x)
             }
         }
     }
-    K3 = pow(K3, 2);
-    U = pow(U, 2);
+    K3 = sq(K3);
+    U = sq(U);
 
     // Binary pair contributions
     for (std::size_t i = 1; i <= NcDetail - 1; ++i){
@@ -336,7 +338,7 @@ static void xTermsDetail(const std::vector<double> &x)
     U = pow(U, 0.2);
 
     // Third virial and higher coefficients
-    Q2 = pow(Q, 2);
+    Q2 = sq(Q);
     for (int n = 13; n <= 58; ++n){
         Csn[n] = an[n] * pow(U, un[n]);
         if (gn[n] == 1) { Csn[n] = Csn[n] * G; }
@@ -385,13 +387,13 @@ static void Alpha0Detail(const double T, const double D, const std::vector<doubl
                         LogHyp = log(std::abs(hsn));
                         SumHyp0 += n0i[i][j] * LogHyp;
                         SumHyp1 += n0i[i][j] * (LogHyp - th0T * hcn / hsn);
-                        SumHyp2 += n0i[i][j] * pow(th0T / hsn, 2);
+                        SumHyp2 += n0i[i][j] * sq(th0T / hsn);
                     }
                     else{
                         LogHyp = log(std::abs(hcn));
                         SumHyp0 += - n0i[i][j] * LogHyp;
                         SumHyp1 += - n0i[i][j] * (LogHyp - th0T * hsn / hcn);
-                        SumHyp2 += + n0i[i][j] * pow(th0T / hcn, 2);
+                        SumHyp2 += + n0i[i][j] * sq(th0T / hcn);
                     }
                 }
             }        

--- a/AGA8CODE/C/Gross.cpp
+++ b/AGA8CODE/C/Gross.cpp
@@ -7,6 +7,7 @@
 #include <math.h>
 #include <cmath>
 #include <iostream>
+#include <cstdlib>
 
 // Version 2.0 of routines for the calculation of thermodynamic
 // properties from the AGA 8 Part 1 GROSS equation of state.
@@ -96,7 +97,7 @@ void MolarMassGross(const std::vector<double> &x, double &Mm)
 //     Mm - Molar mass (g/mol)
 
   Mm = 0;
-  for(int i = 1; i <= NcGross; ++i){
+  for(std::size_t i = 1; i <= NcGross; ++i){
     Mm += x[i] * MMiGross[i];
   }
 }
@@ -225,7 +226,7 @@ void GrossHv(const std::vector<double> &x, std::vector<double> &xGrs, double &HN
     xGrs[2] = x[2];
     xGrs[3] = x[3];
     HN = 0;
-    for(int i = 1; i <= NcGross; ++i){
+    for(std::size_t i = 1; i <= NcGross; ++i){
         HN += x[i]*xHN[i];
     }
     HCH = 0;
@@ -333,15 +334,15 @@ void Bmix(const double T, const std::vector<double> &xGrs, const double HCH, dou
     CC[1][2][3] = 1.1 * pow(CC[1][1][1] * CC[2][2][2] * CC[3][3][3], onethrd); // C(CH-N2-CO2)
 
     // Calculate Bmix and Cmix
-    for (int i = 1; i <= 3; ++i){
-        for(int j = i; j <= 3; ++j){
+    for (std::size_t i = 1; i <= 3; ++i){
+        for(std::size_t j = i; j <= 3; ++j){
             if (i == j){
                 B += BB[i][i]*pow(xGrs[i], 2);
             }
             else{
                 B += 2*BB[i][j]*xGrs[i]*xGrs[j];
             }
-            for(int k = j; k <= 3; ++k){
+            for(std::size_t k = j; k <= 3; ++k){
                 if (i == j && j == k) {
                     C += CC[i][i][i]*pow(xGrs[i], 3);
                 }


### PR DESCRIPTION
Hi, saw that you took a PR, have a small one of my own to submit. Nothing major, replaced ints with size_t for vector indices (Clang was giving a warning), replaced the hyperbolic functions with the standard library ones (these have been included since C90), and replaced some instances of pow(x,2) with an inline function sq.