### PR TITLE
Update GERG2008.cpp to be like the others, add compiler warning flags, and some small fixes

### DIFF
--- a/AGA8CODE/C/CMakeLists.txt
+++ b/AGA8CODE/C/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required (VERSION 2.6)
 project (AGA8)
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    add_compile_options(-Wall -Wextra -Wno-unused-parameter)
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Weverything -Wno-unsafe-buffer-usage -Wno-unused-parameter)
+endif()
+
 add_library(detail SHARED Detail.cpp)
 add_library(gerg SHARED GERG2008.cpp)
 add_library(gross SHARED Gross.cpp)

--- a/AGA8CODE/C/CMakeLists.txt
+++ b/AGA8CODE/C/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.23)
 project (AGA8)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
@@ -8,11 +8,21 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 add_library(detail SHARED Detail.cpp)
-add_library(gerg SHARED GERG2008.cpp)
-add_library(gross SHARED Gross.cpp)
+set_target_properties(detail PROPERTIES PUBLIC_HEADER Detail.h)
 
-add_executable(detail_test_01 Detail_test_01.cpp)
-target_link_libraries(detail_test_01 detail)
+add_library(gerg SHARED GERG2008.cpp)
+set_target_properties(gerg PROPERTIES PUBLIC_HEADER GERG2008.h)
+
+add_library(gross SHARED Gross.cpp)
+set_target_properties(gross PROPERTIES PUBLIC_HEADER Gross.h)
+
+install(TARGETS detail gerg gross
+    LIBRARY DESTINATION lib/${PROJECT_NAME}
+    PUBLIC_HEADER DESTINATION include/${PROJECT_NAME}
+)
+
+add_executable(Detail_test_01 Detail_test_01.cpp)
+target_link_libraries(Detail_test_01 detail)
 
 add_executable(GERG2008_test_01 GERG2008_test_01.cpp)
 target_link_libraries(GERG2008_test_01 gerg)
@@ -21,15 +31,6 @@ add_executable(Gross_test_01 Gross_test_01.cpp)
 target_link_libraries(Gross_test_01 gross)
 
 include(CTest)
-# Detail test gas 01
-add_test(NAME Detail_Gas_01
-    COMMAND detail_test_01
-    )
-
-add_test(NAME GERG2008_Gas_01
-    COMMAND GERG2008_test_01
-    )
-
-add_test(NAME Gross_Gas_01
-    COMMAND Gross_test_01
-    )
+add_test(NAME Detail_test_01 COMMAND Detail_test_01)
+add_test(NAME GERG2008_test_01 COMMAND GERG2008_test_01)
+add_test(NAME Gross_test_01 COMMAND Gross_test_01)

--- a/AGA8CODE/C/Detail.cpp
+++ b/AGA8CODE/C/Detail.cpp
@@ -94,6 +94,7 @@ static double MMiDetail[MaxFlds+1], K3, xold[MaxFlds+1];
 static double dPdDsave; //Calculated in the Pressure subroutine, but not included as an argument since it is only used internally in the density algorithm.
 
 inline double sq(double x) { return x*x; }
+inline double pow5(double x) { return x*x*x*x*x; }
 
 void MolarMassDetail(const std::vector<double> &x, double &Mm)
 {
@@ -943,8 +944,8 @@ void SetupDetail()
                 if (wn[n] == 1) { Bsnij = Bsnij * Wi[i] * Wi[j]; }
                 Bsnij2[i][j][n] = an[n] * pow(Eij[i][j]*sqrt(Ei[i]*Ei[j]), un[n]) * pow(Ki[i]*Ki[j], 1.5) * Bsnij;
             }
-            Kij5[i][j] = (pow(Kij[i][j], 5) - 1)*Ki25[i]*Ki25[j];
-            Uij5[i][j] = (pow(Uij[i][j], 5) - 1)*Ei25[i]*Ei25[j];
+            Kij5[i][j] = (pow5(Kij[i][j]) - 1)*Ki25[i]*Ki25[j];
+            Uij5[i][j] = (pow5(Uij[i][j]) - 1)*Ei25[i]*Ei25[j];
             Gij5[i][j] = (Gij[i][j] - 1)*(Gi[i] + Gi[j])/2;
         }
     }

--- a/AGA8CODE/C/GERG2008.cpp
+++ b/AGA8CODE/C/GERG2008.cpp
@@ -102,6 +102,7 @@ static double taup[MaxFlds+1][MaxTrmP+1], taupijk[MaxFlds+1][MaxTrmM+1];
 static double dPdDsave; //Calculated in the PressureGERG subroutine, but not included as an argument since it is only used internally in the density algorithm.
 
 inline double sq(double x) { return x*x; }
+inline double cb(double x) { return x*x*x; }
 
 void MolarMassGERG(const std::vector<double> &x, double &Mm)
 {
@@ -1517,7 +1518,7 @@ void SetupGERG()
     gvij[i][i] = 1 / Dc[i];
     gtij[i][i] = Tc[i];
     for (std::size_t j = i + 1; j <= MaxFlds; ++j){
-      gvij[i][j] = gvij[i][j] * bvij[i][j] * pow(Vc3[i] + Vc3[j], 3);
+      gvij[i][j] = gvij[i][j] * bvij[i][j] * cb(Vc3[i] + Vc3[j]);
       gtij[i][j] = gtij[i][j] * btij[i][j] * Tc2[i] * Tc2[j];
       bvij[i][j] = sq(bvij[i][j]);
       btij[i][j] = sq(btij[i][j]);

--- a/AGA8CODE/C/GERG2008.cpp
+++ b/AGA8CODE/C/GERG2008.cpp
@@ -99,10 +99,6 @@ static double fij[MaxFlds+1][MaxFlds+1], th0i[MaxFlds+1][7+1], n0i[MaxFlds+1][7+
 static double taup[MaxFlds+1][MaxTrmP+1], taupijk[MaxFlds+1][MaxTrmM+1];
 static double dPdDsave; //Calculated in the PressureGERG subroutine, but not included as an argument since it is only used internally in the density algorithm.
 
-inline double Tanh(double xx){ return (exp(xx) - exp(-xx)) / (exp(xx) + exp(-xx)); }
-inline double Sinh(double xx){ return (exp(xx) - exp(-xx)) / 2; }
-inline double Cosh(double xx){ return (exp(xx) + exp(-xx)) / 2; }
-
 void MolarMassGERG(const std::vector<double> &x, double &Mm)
 {
     // Sub MolarMassGERG(x, Mm)
@@ -1552,10 +1548,10 @@ void SetupGERG()
   // d0 = 101.325 / RGERG / T0;
   // for (int i = 1; i <= MaxFlds; ++i){
   //   n1 = 0; n2 = 0;
-  //   if (th0i[i][4] > epsilon) { n2 += - n0i[i][4] * th0i[i][4] / Tanh(th0i[i][4] / T0); n1 += - n0i[i][4] * log(Sinh(th0i[i][4] / T0)); }
-  //   if (th0i[i][5] > epsilon) { n2 += + n0i[i][5] * th0i[i][5] * Tanh(th0i[i][5] / T0); n1 += + n0i[i][5] * log(Cosh(th0i[i][5] / T0)); }
-  //   if (th0i[i][6] > epsilon) { n2 += - n0i[i][6] * th0i[i][6] / Tanh(th0i[i][6] / T0); n1 += - n0i[i][6] * log(Sinh(th0i[i][6] / T0)); }
-  //   if (th0i[i][7] > epsilon) { n2 += + n0i[i][7] * th0i[i][7] * Tanh(th0i[i][7] / T0); n1 += + n0i[i][7] * log(Cosh(th0i[i][7] / T0)); }
+  //   if (th0i[i][4] > epsilon) { n2 += - n0i[i][4] * th0i[i][4] / tanh(th0i[i][4] / T0); n1 += - n0i[i][4] * log(sinh(th0i[i][4] / T0)); }
+  //   if (th0i[i][5] > epsilon) { n2 += + n0i[i][5] * th0i[i][5] * tanh(th0i[i][5] / T0); n1 += + n0i[i][5] * log(cosh(th0i[i][5] / T0)); }
+  //   if (th0i[i][6] > epsilon) { n2 += - n0i[i][6] * th0i[i][6] / tanh(th0i[i][6] / T0); n1 += - n0i[i][6] * log(sinh(th0i[i][6] / T0)); }
+  //   if (th0i[i][7] > epsilon) { n2 += + n0i[i][7] * th0i[i][7] * tanh(th0i[i][7] / T0); n1 += + n0i[i][7] * log(cosh(th0i[i][7] / T0)); }
   //   n0i[i][3] = n0i[i][3] - 1;
   //   n0i[i][1] = n1 - n2 / T0 + n0i[i][3] * (1 + log(T0));
   //   n0i[i][2] = n2 - n0i[i][3] * T0;

--- a/AGA8CODE/C/GERG2008.cpp
+++ b/AGA8CODE/C/GERG2008.cpp
@@ -597,12 +597,12 @@ static void tTermsGERG(const double lntau, const std::vector<double> &x)
 
     // Calculate temperature dependent parts of the GERG-2008 equation of state
 
-    int i, mn;
+    int p, mn;
     double taup0[12+1];
 
-    i = 5;  // Use propane to get exponents for short form of EOS
-    for (std::size_t k = 1; k <= kpol[i] + kexp[i]; ++k){
-        taup0[k] = exp(toik[i][k] * lntau);
+    p = 5;  // Use propane to get exponents for short form of EOS
+    for (std::size_t k = 1; k <= kpol[p] + kexp[p]; ++k){
+        taup0[k] = exp(toik[p][k] * lntau);
     }
     for (std::size_t i = 1; i <= NcGERG; ++i){
         if (x[i] > epsilon){

--- a/AGA8CODE/C/GERG2008.cpp
+++ b/AGA8CODE/C/GERG2008.cpp
@@ -101,6 +101,8 @@ static double fij[MaxFlds+1][MaxFlds+1], th0i[MaxFlds+1][7+1], n0i[MaxFlds+1][7+
 static double taup[MaxFlds+1][MaxTrmP+1], taupijk[MaxFlds+1][MaxTrmM+1];
 static double dPdDsave; //Calculated in the PressureGERG subroutine, but not included as an argument since it is only used internally in the density algorithm.
 
+inline double sq(double x) { return x*x; }
+
 void MolarMassGERG(const std::vector<double> &x, double &Mm)
 {
     // Sub MolarMassGERG(x, Mm)
@@ -340,7 +342,7 @@ void PropertiesGERG(const double T, const double D, const std::vector<double> &x
     W = 1000 * Cp / Cv * dPdD / Mm;
     if (W < 0) { W = 0; }
     W = sqrt(W);
-    Kappa = pow(W, 2) * Mm / (RT * 1000 * Z);
+    Kappa = sq(W) * Mm / (RT * 1000 * Z);
 }
 
 
@@ -1517,14 +1519,14 @@ void SetupGERG()
     for (std::size_t j = i + 1; j <= MaxFlds; ++j){
       gvij[i][j] = gvij[i][j] * bvij[i][j] * pow(Vc3[i] + Vc3[j], 3);
       gtij[i][j] = gtij[i][j] * btij[i][j] * Tc2[i] * Tc2[j];
-      bvij[i][j] = pow(bvij[i][j], 2);
-      btij[i][j] = pow(btij[i][j], 2);
+      bvij[i][j] = sq(bvij[i][j]);
+      btij[i][j] = sq(btij[i][j]);
     }
   }
 
   for (std::size_t i = 1; i <= MaxMdl; ++i){
     for (std::size_t j = 1; j <= MaxTrmM; ++j){
-      gijk[i][j] = -cijk[i][j] * pow(eijk[i][j], 2) + bijk[i][j] * gijk[i][j];
+      gijk[i][j] = -cijk[i][j] * sq(eijk[i][j]) + bijk[i][j] * gijk[i][j];
       eijk[i][j] = 2 * cijk[i][j] * eijk[i][j] - bijk[i][j];
       cijk[i][j] = -cijk[i][j];
     }

--- a/AGA8CODE/C/Gross.cpp
+++ b/AGA8CODE/C/Gross.cpp
@@ -82,6 +82,7 @@ static double b0[4][4], b1[4][4], b2[4][4], bCHx[3][3], cCHx[3][3];
 static double c0[4][4][4], c1[4][4][4], c2[4][4][4];
 
 inline double sq(double x) { return x*x; }
+inline double cb(double x) { return x*x*x; }
 
 void MolarMassGross(const std::vector<double> &x, double &Mm)
 {
@@ -346,7 +347,7 @@ void Bmix(const double T, const std::vector<double> &xGrs, const double HCH, dou
             }
             for(std::size_t k = j; k <= 3; ++k){
                 if (i == j && j == k) {
-                    C += CC[i][i][i]*pow(xGrs[i], 3);
+                    C += CC[i][i][i]*cb(xGrs[i]);
                 }
                 else if (i != j && j != k && i != k){
                     C += 6*CC[i][j][k]*xGrs[i]*xGrs[j]*xGrs[k];

--- a/AGA8CODE/C/Gross.cpp
+++ b/AGA8CODE/C/Gross.cpp
@@ -613,7 +613,7 @@ int main(){
     DensityGross(T,P,xGrs,HCH,D,ierr,herr);
     printf("Gross method 2-----\n");
     printf("Molar density [mol/l]:              5.197833636353455 != %0.16g\n", D);
-    printf("Volumetric heating value at Td,Pd:  42.15440903329388 != %0.16g\n", Hv2);
+    printf("Volumetric heating value at Td,Pd:  42.15440894466012 != %0.16g\n", Hv2);
 
     xGrs[2] = x[2];
     xGrs[3] = x[3];

--- a/AGA8CODE/C/Gross_test_01.cpp
+++ b/AGA8CODE/C/Gross_test_01.cpp
@@ -31,7 +31,7 @@ int main()
     double HCH_reference    = 1004.738236956522;
     double xGrs_reference[] = {0.0, 0.9199999999999999, 0.02, 0.06};
     double Hv_reference     = 41.37676728724603;
-    double Hv2_reference    = 42.15440903329388;
+    double Hv2_reference    = 42.15440894466012;
 
     printf("Inputs-----\n");
     printf("Temperature [K]:                    300.0000000000000 != %0.16g\n",T);

--- a/AGA8CODE/C/Gross_test_01.cpp
+++ b/AGA8CODE/C/Gross_test_01.cpp
@@ -140,7 +140,7 @@ int main()
     GrossMethod1(Th,Td,Pd,xGrs,Gr,Hv,mm,HCH,HN,ierr,herr);
     DensityGross(T,P,xGrs,HCH,D,ierr,herr);
     printf("Gross method 1-----\n");
-    D = 5.144374668159809;
+    D_reference = 5.144374668159809;
     if (std::abs(D_reference - D) > 1.0e-8)
     {
         printf("Molar density [mol/l]:              %0.16g != %0.16g\n",

--- a/AGA8CODE/C/Gross_test_01.cpp
+++ b/AGA8CODE/C/Gross_test_01.cpp
@@ -147,4 +147,6 @@ int main()
             D_reference, D);
         return_value = EXIT_FAILURE;
     }
+
+    return return_value;
 }


### PR DESCRIPTION
Hi, years ago I did some work on Detail.cpp and Gross.cpp, i.e. change to use hyperbolic functions from the standard library, use size_t for array indices as needed to fix compiler warnings, replace pow(x, 2) with x*x for significant speed boosts. I wanted to make them uniform and apply these changes to all and not just Gross or Detail. I also noticed some problems with the Gross test (this fixes #30), and wanted to add some basic compiler warning flags to CMakeLists.txt. I know this is a lot so let me know if you want me to split up into several PRs, or if you flat out don't want one of them. Cheers.

Edit: I noticed that the Gross test now fails on the heating value -- I reviewed the change and found no reason for it to be different. Upon researching, I found that another case for using the inline multiplication is that integer exponentiation using pow() can introduce floating-point rounding errors, so I think that the new answer is more correct...